### PR TITLE
Perbaikan bug status dan audio

### DIFF
--- a/app/Livewire/Audios/Audio.php
+++ b/app/Livewire/Audios/Audio.php
@@ -31,7 +31,7 @@ class Audio extends Component
     public $tmp_audio2;
     public $audio3;
     public $tmp_audio3;
-    public $status = true; // Default status aktif
+    public $status = 1; // Default status aktif
 
     public $isEdit = false;
     public $showForm = false;
@@ -402,7 +402,7 @@ class Audio extends Component
                 $this->tmp_audio1 = $audio->audio1;
                 $this->tmp_audio2 = $audio->audio2;
                 $this->tmp_audio3 = $audio->audio3;
-                $this->status     = $audio->status;
+                $this->status     = $audio->status ? 1 : 0;
                 $this->isEdit     = true;
             } else {
                 $this->isEdit = false;
@@ -511,7 +511,7 @@ class Audio extends Component
         $this->tmp_audio1 = $audio->audio1;
         $this->tmp_audio2 = $audio->audio2;
         $this->tmp_audio3 = $audio->audio3;
-        $this->status     = $audio->status;
+        $this->status     = $audio->status ? 1 : 0;
 
         $this->isEdit     = true;
         $this->showForm   = true;
@@ -579,7 +579,7 @@ class Audio extends Component
             }
 
             $audio->user_id = $this->userId;
-            $audio->status = $this->status;
+            $audio->status = $this->status ? 1 : 0;
 
             // Ambil prefix dari konfigurasi (untuk upload, bukan penghapusan)
             $prefix = config('filesystems.disks.cloudinary.prefix', '');
@@ -694,7 +694,7 @@ class Audio extends Component
                     $this->tmp_audio1 = $audio->audio1;
                     $this->tmp_audio2 = $audio->audio2;
                     $this->tmp_audio3 = $audio->audio3;
-                    $this->status     = $audio->status;
+                    $this->status     = $audio->status ? 1 : 0;
                     $this->isEdit     = true;
                 }
             }

--- a/resources/views/livewire/audios/audio.blade.php
+++ b/resources/views/livewire/audios/audio.blade.php
@@ -93,6 +93,12 @@
                                             <div class="row g-2 mb-3">
                                                 <div class="col-md-4 mb-2 px-2">
                                                     <label class="form-label">Status</label>
+                                                    <label class="form-text small text-muted mb-2 ">
+                                                        👉
+                                                        Audio tidak akan tampil jika status tidak aktif. Audio akan
+                                                        berhenti 1 menit sebelum adzan dan akan play kembali setelah
+                                                        fase adzan, iqomah dan final selesai.
+                                                    </label>
                                                     <select
                                                         class="form-select rounded-3 @error('status') is-invalid @enderror"
                                                         wire:model="status">

--- a/routes/web.php
+++ b/routes/web.php
@@ -248,7 +248,7 @@ Route::get('/api/server-time', function () {
             $serverTime = $response['serverTime'];
             $serverDateTime = new \DateTime($serverTime, new \DateTimeZone('UTC'));
             $serverDateTime->setTimezone(new \DateTimeZone('Asia/Jakarta'));
-            // $serverDateTime->modify('+5 hour 45 minutes'); // Tambah 1 jam 20 menit
+            // $serverDateTime->modify('+0 hour 48 minutes'); // Tambah 1 jam 20 menit
 
             // untuk testing hari jumat
             // $currentDay = (int)$serverDateTime->format('w');


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Audio playback now automatically pauses one minute before prayer time (adzan) and resumes after prayer-related phases are completed.

* **Improvements**
  * Simplified audio playback logic for smoother and more reliable operation.
  * Updated the audio settings form with a label clarifying how status and prayer times affect audio playback.

* **Documentation**
  * Added explanatory text to the audio status dropdown in the settings form. 

* **Chores**
  * Updated comments for clarity in server time route (no user-facing impact).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->